### PR TITLE
Update to support receiving the "HeadIsOpen" event from the Hydra head

### DIFF
--- a/src/hydra/mod.rs
+++ b/src/hydra/mod.rs
@@ -77,6 +77,10 @@ impl HydraAdapter {
                         Event::SnapshotConfirmed { snapshot } => {
                             self.update_utxos(snapshot.utxo).await;
                         }
+                        Event::HeadIsOpen { snapshot } => {
+                            self.update_utxos(snapshot).await;
+                            *self.head_status.write().await = HeadStatus::Open;
+                        }
                     },
 
                     Err(_) => {

--- a/src/hydra/model.rs
+++ b/src/hydra/model.rs
@@ -18,6 +18,10 @@ pub enum Event {
     SnapshotConfirmed {
         snapshot: Snapshot,
     },
+    HeadIsOpen {
+        #[serde(alias = "utxo")]
+        snapshot: HashMap<TxID, Utxo>
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
When we are connecting to a live network and TRP is connected to the Hydra node BEFORE it has been initialized with seed commits from the head participants.

Attempting to correctly catch this pattern:
```javascript
{
  headId: 'b1b66a4f174e1d84cd5a080c6a5865cb824f313b9a766053df81416f',
  seq: 9,
  tag: 'HeadIsOpen',
  timestamp: '2025-07-30T01:42:07.703071455Z',
  utxo: {
    'a000003f633d9b2efcc18dedefaf60623e3132c8b05a5751ac08d3bf6f505d54#1': {
      address: 'addr_test1vpkyw6w6cu6j8ms7gp366skzen3y4xrjxk67qyurmgvy88cmztduv',
      datum: null,
      datumhash: null,
      inlineDatum: null,
      inlineDatumRaw: null,
      referenceScript: null,
      value: [Object]
    }
  }
}
```