### PR TITLE
Add Feature: Max Connections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,21 @@ jobs:
         include:
           - context: .
             file: Dockerfile
-            endpoint: tx3-lang/tx3-hydra
+            endpoint: ${{ github.repository }}
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,22 +9,17 @@ on:
       - "!examples/**"
 
 jobs:
-  boros:
+  build:
     permissions:
       contents: read
       packages: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - context: .
-            file: Dockerfile
-            endpoint: ${{ github.repository }}
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -36,8 +31,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
+          context: .
+          file: Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ matrix.endpoint }},ghcr.io/${{ matrix.endpoint }}:${{ github.sha }}
+          tags: ${{ env.IMAGE }},${{ env.IMAGE }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Example `config.toml`:
 listen_address = "0.0.0.0:8164"
 permissive_cors = false
 max_optimize_rounds = 10
+max_connections = 100 # Maximum concurrent WebSocket connections (default: 100)
 
 [hydra]
 network = 0 # Cardano network ID (e.g., 0 for Testnet, 1 for Mainnet)

--- a/src/hydra/mod.rs
+++ b/src/hydra/mod.rs
@@ -194,7 +194,7 @@ impl HydraAdapter {
         *self.progress.write().await = Progress { seq, timestamp };
     }
 
-    pub async fn read_utxos(&self) -> UtxoSnapshot {
+    pub async fn read_utxos(&self) -> UtxoSnapshot<'_> {
         UtxoSnapshot(self.utxos.read().await)
     }
 }

--- a/src/hydra/model.rs
+++ b/src/hydra/model.rs
@@ -107,6 +107,7 @@ pub struct Utxo {
     pub datumhash: Option<String>,
 
     #[serde(rename = "inlineDatum")]
+    #[allow(dead_code)]
     pub inline_datum: Option<serde_json::Value>,
 
     /// Base16 encoding

--- a/src/trp/mod.rs
+++ b/src/trp/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use jsonrpsee::{RpcModule, server::Server};
+use jsonrpsee::{RpcModule, server::Server, server::ServerConfig};
 use serde::Deserialize;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -27,7 +27,11 @@ pub async fn run(
     };
 
     let middleware = ServiceBuilder::new().layer(cors_layer);
+    let server_config = ServerConfig::builder()
+        .max_connections(config.max_connections)
+        .build();
     let server = Server::builder()
+        .set_config(server_config)
         .set_http_middleware(middleware)
         .build(&config.listen_address)
         .await?;
@@ -83,6 +87,10 @@ fn default_max_optimize_rounds() -> usize {
     10
 }
 
+fn default_max_connections() -> u32 {
+    100
+}
+
 #[derive(Deserialize, Clone)]
 pub struct Config {
     listen_address: String,
@@ -90,4 +98,6 @@ pub struct Config {
     permissive_cors: bool,
     #[serde(default = "default_max_optimize_rounds")]
     max_optimize_rounds: usize,
+    #[serde(default = "default_max_connections")]
+    max_connections: u32,
 }


### PR DESCRIPTION
`jsonrpsee` has a configuration option to set the number of max connections allowed. This currently defaults to 100. When using high-frequency transactions inside of a Hydra head, particularly through programmatic stress testing, this limit can be overly restrictive.

This update simply introduces a `max_connections` configuration variable (defaults to 100) that changes the connection limit of the TRP instance.

Also, I updated the GitHub action to allow the build to be run on forks and not attempt to push to the Tx3 GHCR...