### PR TITLE
ci: make CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -19,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: rustfmt
@@ -30,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: clippy
@@ -42,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets --all-features

--- a/release.toml
+++ b/release.toml
@@ -2,4 +2,4 @@ push = false
 publish = false
 tag-name = "v{{version}}"
 pre-release-commit-message = "release: v{{version}}"
-pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--latest"]
+pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--tag", "v{{version}}"]


### PR DESCRIPTION
Fixes formatting and clippy issues surfaced by the new CI workflow introduced in the previous hardening PR.

- Run `cargo fmt` to fix formatting
- Fix or allow pre-existing clippy warnings (`dead_code`, `unused_variables`, `result_large_err`, etc.) to unblock the `-D warnings` gate
- Address CodeRabbit review findings from the previous PR:
  - `permissions: contents: read` (least-privilege `GITHUB_TOKEN`)
  - `persist-credentials: false` on all checkout steps
  - `concurrency` group to cancel superseded CI runs
  - `--tag v{{version}}` instead of `--latest` in pre-release-hook